### PR TITLE
Fix ITI-68 retrieval for FHIR Documents: use Bundle, not Binary

### DIFF
--- a/input/pagecontent/example-patient-summary.md
+++ b/input/pagecontent/example-patient-summary.md
@@ -41,8 +41,8 @@ sequenceDiagram
     Note over Consumer,Provider: Document Exchange (MHD ITI-67, ITI-68)
     Consumer->>Provider: GET /DocumentReference?patient=...&type=60591-5
     Provider-->>Consumer: DocumentReference Bundle
-    Consumer->>Provider: GET /Binary/[id]
-    Provider-->>Consumer: Patient Summary Document
+    Consumer->>Provider: GET /Bundle/[id]
+    Provider-->>Consumer: Patient Summary (FHIR Document)
     end
 ```
 
@@ -69,7 +69,7 @@ POST https://provider.example.org/auth/token
 Content-Type: application/x-www-form-urlencoded
 
 grant_type=client_credentials
-&scope=system/Patient.rs system/DocumentReference.rs system/Binary.r
+&scope=system/Patient.rs system/DocumentReference.rs system/Bundle.r
 &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
 &client_assertion=[signed JWT]
 ```
@@ -122,7 +122,7 @@ Response Bundle contains DocumentReference resources for available Patient Summa
   "content": [{
     "attachment": {
       "contentType": "application/fhir+json",
-      "url": "Binary/binary-456"
+      "url": "Bundle/ips-bundle-456"
     },
     "format": {
       "system": "http://ihe.net/fhir/ihe.formatcode.fhir/CodeSystem/formatcode",
@@ -135,21 +135,23 @@ Response Bundle contains DocumentReference resources for available Patient Summa
 
 #### Step 5: Retrieve Document Content
 
-Document Consumer retrieves the document content using **IHE MHD ITI-68** (Retrieve Document) transaction.
+Document Consumer retrieves the document content using **IHE MHD ITI-68** (Retrieve Document) transaction. The URL is taken from `DocumentReference.content.attachment.url`.
 
 ```
-GET https://provider.example.org/fhir/Binary/binary-456
+GET https://provider.example.org/fhir/Bundle/ips-bundle-456
 Authorization: Bearer [access_token]
 ```
 
-Response is the Patient Summary as a FHIR Bundle (document) in JSON format.
+Response is the Patient Summary as a FHIR Document (Bundle of type `document`) in JSON format.
+
+> **Note:** Patient Summary (IPS) is a FHIR Document, so it is retrieved as a Bundle resource, not a Binary. See [Document Exchange - FHIR Documents vs Binary](document-exchange.html#fhir-documents-vs-binary) for details.
 
 ### Key Points
 
 - All resource access requires [authorization](authorization.html)
 - Patient identification precedes health data queries
 - DocumentReference contains metadata about documents
-- Binary resource contains the actual document content
+- FHIR Documents (IPS, etc.) are retrieved as Bundle resources; non-FHIR documents (PDF) are retrieved as Binary resources
 - All transactions use standard FHIR RESTful interactions
 
 ### Variations

--- a/input/pagecontent/priority-area-hdr.md
+++ b/input/pagecontent/priority-area-hdr.md
@@ -18,7 +18,7 @@ Hospital discharge reports provide clinical summaries at the end of a hospital s
 
 Hospital discharge reports are retrieved using the same pattern as other documents. The retrieval workflow follows the standard sequence:
 
-1. **Authorization** - Obtain access token with `system/DocumentReference.rs system/Binary.r` scopes
+1. **Authorization** - Obtain access token with `system/DocumentReference.rs` and document retrieval scope (see [Document Exchange](document-exchange.html#fhir-documents-vs-binary))
 2. **Patient Lookup** - Identify the patient using ITI-78 (PDQm)
 3. **Document Search** - Search for discharge summaries using ITI-67 with `type=http://loinc.org|18842-5`
 4. **Document Retrieval** - Retrieve the document content using ITI-68

--- a/input/pagecontent/priority-area-imaging-report.md
+++ b/input/pagecontent/priority-area-imaging-report.md
@@ -17,7 +17,7 @@ Diagnostic imaging reports in this IG follow the [EU Imaging Report Implementati
 
 Imaging reports are retrieved using the same pattern as other documents. The retrieval workflow follows the standard sequence:
 
-1. **Authorization** - Obtain access token with `system/DocumentReference.rs system/Binary.r` scopes
+1. **Authorization** - Obtain access token with `system/DocumentReference.rs` and document retrieval scope (see [Document Exchange](document-exchange.html#fhir-documents-vs-binary))
 2. **Patient Lookup** - Identify the patient using ITI-78 (PDQm)
 3. **Document Search** - Search for imaging reports using ITI-67 with `type=http://loinc.org|68604-8`
 4. **Document Retrieval** - Retrieve the document content using ITI-68

--- a/input/pagecontent/priority-area-laboratory.md
+++ b/input/pagecontent/priority-area-laboratory.md
@@ -16,7 +16,7 @@ Laboratory reports in this IG follow the [EU Laboratory Report Implementation Gu
 
 Laboratory reports are retrieved using the same pattern as other documents. The retrieval workflow follows the standard sequence:
 
-1. **Authorization** - Obtain access token with `system/DocumentReference.rs system/Binary.r` scopes
+1. **Authorization** - Obtain access token with `system/DocumentReference.rs` and document retrieval scope (see [Document Exchange](document-exchange.html#fhir-documents-vs-binary))
 2. **Patient Lookup** - Identify the patient using ITI-78 (PDQm)
 3. **Document Search** - Search for laboratory reports using ITI-67 with `type=http://loinc.org|11502-2`
 4. **Document Retrieval** - Retrieve the document content using ITI-68


### PR DESCRIPTION
FHIR Documents (IPS, etc.) are retrieved via /Bundle/[id] per MHD Section 2:3.65.4.1.2.1 (FHIR Document Publish Option), not /Binary/[id].

- Add "FHIR Documents vs Binary" section to document-exchange.md
- Fix example-patient-summary.md to use Bundle endpoint and scope
- Update priority area pages to reference new documentation