### PR TITLE
Align DocumentReference profile to MHD Minimal (date, custodian)

### DIFF
--- a/input/fsh/mhd/documentreference-mhd.fsh
+++ b/input/fsh/mhd/documentreference-mhd.fsh
@@ -16,5 +16,5 @@ See [Document Exchange](document-exchange.html) for query examples.
 * type from EEHRxFDocumentTypeVS (preferred)
 * subject 1..1
 * subject only Reference( http://hl7.eu/fhir/base/StructureDefinition/patient-eu-core )
-* date 1..1
-* custodian 1..1
+// `date` and `custodian` intentionally inherit MHD Minimal cardinality (0..1);
+// the IG previously constrained both to 1..1 without justification. FHIR-56711, FHIR-56700.


### PR DESCRIPTION
Example implementation of part of the **ITI-67 / MHD Document Query** reconciliation. Discussion page: https://confluence.hl7.org/x/flgOGw

## What this changes

`EehrxfMhdDocumentReference` already derives from MHD Minimal but tightened two elements to `1..1` without justification. This removes those tightenings so the profile inherits MHD Minimal's `0..1`:

- `DocumentReference.date` `1..1` → inherits `0..1` — **FHIR-56711** (`.date` is the index/registration time, not the clinical document time; should not be mandatory)
- `DocumentReference.custodian` `1..1` → inherits `0..1` — **FHIR-56700** (MHD makes custodian optional; no member-state flag justifies diverging)

Both keep our output fully MHD-conformant — this only removes constraints stricter than MHD.

SUSHI builds clean (0 errors, 0 warnings).

## Not included here (deliberately)

- **`category` multiplicity (FHIR-56856 / FHIR-56710):** opening `category` to `0..*` **cannot be expressed on a Minimal-derived profile** — MHD Minimal caps `category` at `0..1` and FHIR profiling only allows narrowing. This requires a parenting decision and belongs to the `.type`/`.category` topic, not this PR.
- **Search-parameter SHALL promotions + `creation`:** scope of PR #83.
- **`type`/`category` value-set bindings:** the `.type`/`.category` topic.