### PR TITLE
Clarify HPAS and HDAS definitions

### DIFF
--- a/input/pagecontent/usecase-health-data-portal.md
+++ b/input/pagecontent/usecase-health-data-portal.md
@@ -1,6 +1,6 @@
 ### Overview
 
-A **Health Data Access Service** ([Art. 4](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202500327#art_4)) enables a patient to access their own health data from EHR systems. The service authenticates the patient and queries EHR systems on the patient's behalf.
+A **Health Data Access Service** ([Art. 4](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202500327#art_4)) is provided by a Member State to natural persons or their representatives for accessing their health data. The service can be delivered as a web portal, an API, or other means. It authenticates the patient and queries EHR systems on the patient's behalf. The infrastructure behind these services is country-specific — see [Member State Architectures](member-state-architectures.html).
 
 ### Scope
 

--- a/input/pagecontent/usecase-health-data-portal.md
+++ b/input/pagecontent/usecase-health-data-portal.md
@@ -1,6 +1,6 @@
 ### Overview
 
-A **Health Data Access Service** ([Art. 4](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202500327#art_4)) is provided by a Member State to natural persons or their representatives for accessing their health data. The service can be delivered as a web portal, an API, or other means. It authenticates the patient and queries EHR systems on the patient's behalf. The infrastructure behind these services is country-specific — see [Member State Architectures](member-state-architectures.html).
+A **Health Data Access Service** ([Art. 4](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202500327#art_4)) is provided by a Member State to natural persons or their representatives for accessing their health data. The service can be delivered as a web portal, an API, or other means. It authenticates the patient and accesses data from EHR systems on the patient's behalf. The infrastructure behind these services is country-specific — see [Member State Architectures](member-state-architectures.html).
 
 ### Scope
 

--- a/input/pagecontent/usecase-health-professional-portal.md
+++ b/input/pagecontent/usecase-health-professional-portal.md
@@ -1,6 +1,6 @@
 ### Overview
 
-A **Health Professional Access Service** ([Art. 12](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202500327#art_12)) enables a health professional to query patient health information from EHR systems. The service authenticates the professional, locates the patient, and queries one or more EHR systems for that patient's data.
+A **Health Professional Access Service** ([Art. 12](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202500327#art_12)) is provided by a Member State to health professionals for accessing their patients' health data. The service can be delivered as a web portal, an API, or other means. It authenticates the professional, locates the patient, and queries one or more EHR systems. The infrastructure behind these services is country-specific — see [Member State Architectures](member-state-architectures.html).
 
 ### Scope
 

--- a/input/pagecontent/usecase-health-professional-portal.md
+++ b/input/pagecontent/usecase-health-professional-portal.md
@@ -1,6 +1,6 @@
 ### Overview
 
-A **Health Professional Access Service** ([Art. 12](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202500327#art_12)) is provided by a Member State to health professionals for accessing their patients' health data. The service can be delivered as a web portal, an API, or other means. It authenticates the professional, locates the patient, and queries one or more EHR systems. The infrastructure behind these services is country-specific — see [Member State Architectures](member-state-architectures.html).
+A **Health Professional Access Service** ([Art. 12](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202500327#art_12)) is provided by a Member State to health professionals for accessing their patients' health data. The service can be delivered as a web portal, an API, or other means. It authenticates the professional, locates the patient, and accesses data from EHR systems. The infrastructure behind these services is country-specific — see [Member State Architectures](member-state-architectures.html).
 
 ### Scope
 


### PR DESCRIPTION
## Summary

- Clarify that Member States provide HPAS to health professionals.
- Clarify that Member States provide HDAS to natural persons or their representatives.
- Note that either service may be delivered as a web portal, API, or other means, and link both definitions to Member State Architectures.

## Ballot tickets

- [FHIR-56477 — Definition of the HPAS](https://jira.hl7.org/browse/FHIR-56477)
- [FHIR-56478 — Definition of the HDAS](https://jira.hl7.org/browse/FHIR-56478)

## Scope

This is a non-substantive clarification of two definitions. The merged deployment-scenarios work already supplies the surrounding architecture; this PR changes only the two overview paragraphs.

Prepared for the July 29 workgroup disposition vote.

## Verification

- Branch is based directly on current `main`.
- `git diff --check origin/main...HEAD` passes.
- Net diff: two files, two paragraph replacements.
